### PR TITLE
updating the ember install line to fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use [uuid](https://github.com/kelektiv/node-uuid) in your Ember project.
 ## Installation
 
 ```
-ember install ember-node-uuid-shim
+ember install ember-uuid-shim
 ```
 
 


### PR DESCRIPTION
This PR fixes the typo` ember-node-uuid-shim` should be `ember-uuid-shim`.